### PR TITLE
fix(GanttChart/index.vue): :bug: Fix to successfully remove mousemove…

### DIFF
--- a/src/components/GanttChart/index.vue
+++ b/src/components/GanttChart/index.vue
@@ -327,7 +327,7 @@ export default {
     },
 
     taskSpawnEnd() {
-      window.removeEventListener("mousemove", this.taskSpawn);
+      document.removeEventListener("mousemove", this.taskSpawn);
       if (this.taskSpawnData?.firstCall) this.taskSpawnCancel();
     },
 


### PR DESCRIPTION
The registration is on the document element, and the removal is on the windows element, and the removal cannot be successful